### PR TITLE
save and initialize actuators on startup

### DIFF
--- a/source-code/application.lua
+++ b/source-code/application.lua
@@ -1,19 +1,15 @@
 local sensorSend = { }
 
-function initializePins()
-	for i,sensor in pairs(sensors) do
-		print('Initializing sensor on pin ' .. sensor.pin)
-		gpio.mode(sensor.pin, gpio.INPUT, gpio.PULLUP)
-	end
-
-	for i,actuator in pairs(actuators) do
-		print('Initializing actuator on pin ' .. actuator.pin)
-		gpio.mode(actuator.pin, gpio.OUTPUT)
-		gpio.write(actuator.pin, gpio.LOW)
-	end
+for i,sensor in pairs(sensors) do
+  print('Initializing sensor on pin ' .. sensor.pin)
+  gpio.mode(sensor.pin, gpio.INPUT, gpio.PULLUP)
 end
 
-initializePins()
+for i,actuator in pairs(actuators) do
+  print('Initializing actuator on pin ' .. actuator.pin)
+  gpio.mode(actuator.pin, gpio.OUTPUT)
+  gpio.write(actuator.pin, gpio.LOW)
+end
 
 tmr.create():alarm(200, tmr.ALARM_AUTO,function(t)
 	for i, sensor in pairs(sensors) do
@@ -33,4 +29,8 @@ tmr.create():alarm(200, tmr.ALARM_AUTO, function(t)
 			t:start()
 		end)
 	end
+end)
+
+tmr.create():alarm(5000, tmr.ALARM_AUTO, function()
+  print("Memory: " .. node.heap())
 end)

--- a/source-code/application.lua
+++ b/source-code/application.lua
@@ -1,8 +1,19 @@
 local sensorSend = { }
 
-for i,sensor in pairs(sensors) do
-	gpio.mode(sensor.pin, gpio.INPUT, gpio.PULLUP)
+function initializePins()
+	for i,sensor in pairs(sensors) do
+		print('Initializing sensor on pin ' .. sensor.pin)
+		gpio.mode(sensor.pin, gpio.INPUT, gpio.PULLUP)
+	end
+
+	for i,actuator in pairs(actuators) do
+		print('Initializing actuator on pin ' .. actuator.pin)
+		gpio.mode(actuator.pin, gpio.OUTPUT)
+		gpio.write(actuator.pin, gpio.LOW)
+	end
 end
+
+initializePins()
 
 tmr.create():alarm(200, tmr.ALARM_AUTO,function(t)
 	for i, sensor in pairs(sensors) do

--- a/source-code/server.lua
+++ b/source-code/server.lua
@@ -7,22 +7,26 @@ httpd_set("/favicon.ico", function(request, response)
     response:contentType("image/x-icon")
     response:file("http_favicon.ico")
 end)
-httpd_set("/settings", function(request, response) 
+httpd_set("/settings", function(request, response)
+	local function buildLuaTable(objects)
+		local out = "{ "
+		for i,object in pairs(objects) do
+			out = out .. "\r\n{ pin = "..object.pin.." }"
+			if i < #objects then
+				out = out .. ","
+			end
+		end
+		return out .. " }"
+	end
+
 	if request.contentType == "application/json" then
 		if request.method == "PUT" then
-			local sensors = "{ "
-			for i,sensor in pairs(request.body.sensors) do
-				if i == #request.body.sensors then 
-					sensors = sensors.."\r\n{ pin = "..sensor.pin.." }"
-				else
-					sensors = sensors.."\r\n{ pin = "..sensor.pin.." },"
-				end
-				gpio.mode(sensor.pin, gpio.INPUT, gpio.PULLUP)
-			end
-			sensors = sensors.." }"
+			local sensors = buildLuaTable(request.body.sensors)
+		  local actuators = buildLuaTable(request.body.actuators)
 			variables_set("smartthings", "{ token = \"" .. request.body.token .. "\",\r\n apiUrl = \""..request.body.apiUrl.."\" }")
 			variables_set("sensors", sensors)
-			require("application")
+			variables_set("actuators", actuators)
+			initializePins()
 			response:contentType("application/json")
 			response:status("204")
 			response:send("")
@@ -40,7 +44,6 @@ httpd_set("/device", function(request, response)
 			response:send(cjson.encode(body))
 		end
 		if request.method == "PUT" then
-			gpio.mode(request.body.pin, gpio.OUTPUT)
 			gpio.write(request.body.pin, request.body.state)
 			response:contentType("application/json")
 			response:status("204")

--- a/source-code/server.lua
+++ b/source-code/server.lua
@@ -26,11 +26,14 @@ httpd_set("/settings", function(request, response)
 			variables_set("smartthings", "{ token = \"" .. request.body.token .. "\",\r\n apiUrl = \""..request.body.apiUrl.."\" }")
 			variables_set("sensors", sensors)
 			variables_set("actuators", actuators)
-			initializePins()
+
+			print('Settings updated! Restarting in 2 seconds...')
+			tmr.create():alarm(2000, tmr.ALARM_SINGLE, node.restart)
+
 			response:contentType("application/json")
 			response:status("204")
 			response:send("")
-		end            
+		end
 	end
 end)
 httpd_set("/device", function(request, response) 

--- a/source-code/variables.lua
+++ b/source-code/variables.lua
@@ -19,6 +19,7 @@ function variables_set(name,value)
 	local f = file.open(fn, "w")
 	f.writeline(name.." = "..value)
 	f.close()
+	print('Wrote ' .. fn)
 	variables_load()
 	collectgarbage()
 end


### PR DESCRIPTION
Hey @copy-ninja! I'm starting to really dig into your code today. Here's the first of probably a series of PRs with little tweaks and changes to get the application closer to feature parity with my initial nodemcu-smartthings project so that it doesn't confuse users who upgrade. So far everything works great, I just have a few ideas to polish up. I will try to keep my pull requests small and atomic.

This first change saves the `actuators` configuration after `/settings` and ensures that the actuator is set to `GPIO.low` on startup. 